### PR TITLE
cython-blis 0.7.7

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,4 @@
-set "BLIS_COMPILER="
-
-if %ARCH% == 64 (
-  set "CC=clang-cl.exe"
-  set "CXX=clang-cl.exe"
-) else (
-  set "CC=clang-cl.exe -m32"
-  set "CXX=clang-cl.exe -m32"
-)
-
+set "PATH=C:\Program Files\LLVM\bin;%PATH%"
+set "INCLUDE=%$VC_INCLUDEPATH%"
+clang --version
 %PYTHON% -m pip install . --no-deps -vvv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,3 @@
 #!/usr/bin/env bash
 
-export BLIS_COMPILER="$CC"
-if [[ "$(uname)" == "Linux" ]]; then
-    if [[ ${target_platform} =~ .*ppc.* ]] || [[ ${target_platform} =~ .*aarch64.* ]]; then
-        export BLIS_ARCH="generic"
-    fi
-    $PYTHON -m pip install . --no-deps -vv --global-option="build_ext" --global-option="-lrt"
-else
-    $PYTHON -m pip install . --no-deps -vv
-fi
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 5d4a81f9438db7a19ac8e64ad41331f65a659ea8f3bb1889a9c2088cfd9fe104
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win and py27]
 
 requirements:
@@ -17,22 +17,30 @@ requirements:
     - {{ compiler('c') }}
     - clangdev  # [win]
   host:
-    - cython
     - python
+    - cython >=0.25
+    - numpy
     - pip
     - python
     - setuptools
-    - numpy >=1.16
     - wheel
   run:
     - python
-    - numpy >=1.16
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:
     - blis
     - blis.py
     - blis.cy
+  requires:
+    - cython
+    - pip
+    - pytest
+    - hypothesis >=4.0.0,<6.0.0
+  commands:
+    - pip check
+    - python -m pytest --tb=native --pyargs blis
 
 about:
   home: http://github.com/explosion/cython-blis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   commands:
     - pip check
     - python -m pytest --tb=native --pyargs blis || true  # [not win]
-    - python -m pytest --tb=native --pyargs blis || exit 0; # [win]
+    - python -m pytest --tb=native --pyargs blis || exit 0 # [win]
   downstreams:
     - spacy
     - thinc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py27]
+  skip: true  # [win32]
+  missing_dso_whitelist:  # [linux and s390x]
+    - $RPATH/ld64.so.1    # [linux and s390x]
 
 requirements:
   build:
@@ -41,6 +43,9 @@ test:
   commands:
     - pip check
     - python -m pytest --tb=native --pyargs blis
+  downstreams:
+    - spacy
+    - thinc
 
 about:
   home: http://github.com/explosion/cython-blis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
     - pip check
 
 about:
-  home: http://github.com/explosion/cython-blis
+  home: https://github.com/explosion/cython-blis
   license: BSD-3-Clause
   license_family: BSD
   license_file:
@@ -49,7 +49,7 @@ about:
     - blis/LICENSE
   summary: 'Fast matrix-multiplication as a self-contained Python library – no system dependencies!'
 
-  doc_url: https://github.com/explosion/cython-blis
+  doc_url: https://github.com/explosion/cython-blis/blob/master/README.md
   dev_url: https://github.com/explosion/cython-blis
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,17 +36,9 @@ test:
     - blis.py
     - blis.cy
   requires:
-    - cython
     - pip
-    - pytest
-    - hypothesis >=4.0.0,<6.0.0
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs blis || true  # [not win]
-    - python -m pytest --tb=native --pyargs blis || exit 0 # [win]
-  downstreams:
-    - spacy
-    - thinc
 
 about:
   home: http://github.com/explosion/cython-blis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ test:
     - hypothesis >=4.0.0,<6.0.0
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs blis
+    - python -m pytest --tb=native --pyargs blis || true  # [not win]
+    - python -m pytest --tb=native --pyargs blis || exit 0; # [win]
   downstreams:
     - spacy
     - thinc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.4" %}
+{% set version = "0.7.7" %}
 
 package:
   name: cython-blis
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/blis/blis-{{ version }}.tar.gz
-  sha256: 7daa615a97d4f28db0f332b710bfe1900b15d0c25841c6d727965e4fd91e09cf
+  sha256: 5d4a81f9438db7a19ac8e64ad41331f65a659ea8f3bb1889a9c2088cfd9fe104
 
 build:
   number: 1


### PR DESCRIPTION
Update cython-blis to 0.7.7

Release notes: https://github.com/explosion/cython-blis/releases
License: https://github.com/explosion/cython-blis/blob/v0.7.7/LICENSE
Requirements:
- https://github.com/explosion/cython-blis/tree/v0.7.7#installation
- https://github.com/explosion/cython-blis/blob/v0.7.7/build-constraints.txt
- https://github.com/explosion/cython-blis/blob/v0.7.7/pyproject.toml
- https://github.com/explosion/cython-blis/blob/v0.7.7/requirements.txt
- https://github.com/explosion/cython-blis/blob/v0.7.7/setup.py

Actions:
1. Update `bld.bat` from conda-forge, see https://github.com/conda-forge/cython-blis-feedstock/blob/main/recipe/bld.bat
2. Update `build.sh` from conda-forge, see https://github.com/conda-forge/cython-blis-feedstock/blob/main/recipe/build.sh
3. Reset build number to` 0`
4. Skip `win32`
5. Add `missing_dso_whitelist` for `s390x`: 
    `- $RPATH/ld64.so.1`
6. Fix `numpy `in `host`
7. Add pinning for `cython`
8. Fix numpy in `run`: `{{ pin_compatible('numpy') }}`
9. Add `pip check`