### PR TITLE
cython-blis 0.7.9

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,4 @@
 set "PATH=C:\Program Files\LLVM\bin;%PATH%"
 set "INCLUDE=%$VC_INCLUDEPATH%"
 clang --version
-%PYTHON% -m pip install . --no-deps -vvv
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-$PYTHON -m pip install . --no-deps -vv
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.7" %}
+{% set version = "0.7.9" %}
 
 package:
   name: cython-blis
@@ -6,11 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/blis/blis-{{ version }}.tar.gz
-  sha256: 5d4a81f9438db7a19ac8e64ad41331f65a659ea8f3bb1889a9c2088cfd9fe104
+  sha256: 29ef4c25007785a90ffc2f0ab3d3bd3b75cd2d7856a9a482b7d0dac8d511a09d
 
 build:
   number: 0
-  skip: true  # [win32]
   missing_dso_whitelist:  # [linux and s390x]
     - $RPATH/ld64.so.1    # [linux and s390x]
 
@@ -20,10 +19,9 @@ requirements:
     - clangdev  # [win]
   host:
     - python
-    - cython >=0.25
-    - numpy
+    - cython 0.29.32
+    - numpy  {{ numpy }}
     - pip
-    - python
     - setuptools
     - wheel
   run:
@@ -48,7 +46,8 @@ about:
     - LICENSE
     - blis/LICENSE
   summary: 'Fast matrix-multiplication as a self-contained Python library – no system dependencies!'
-
+  description: |
+    cython-blis provides the Blis linear algebra routines as a self-contained Python C-extension.
   doc_url: https://github.com/explosion/cython-blis/blob/master/README.md
   dev_url: https://github.com/explosion/cython-blis
 


### PR DESCRIPTION
License: https://github.com/explosion/cython-blis/blob/v0.7.9/LICENSE
Requirements:
- https://github.com/explosion/cython-blis/blob/v0.7.9/pyproject.toml
- https://github.com/explosion/cython-blis/blob/v0.7.9/requirements.txt
- https://github.com/explosion/cython-blis/blob/v0.7.9/setup.py

Notes:
- `thinc 8.1.10` requires `cython-blis >=0.7.8,<0.8.0` but we have **v0.7.7**