### PR TITLE
Rebuild for py314

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,0 @@
-c_compiler_version:      # [osx]
-  - 14                   # [osx]
-cxx_compiler_version:    # [osx]
-  - 14                   # [osx]
-MACOSX_SDK_VERSION:      # [osx]
-  - 11.1                 # [osx]
-CONDA_BUILD_SYSROOT:     # [osx]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,8 @@ source:
     - patches/0001-Disable-obsolete-AVX512-flags.patch  # [win]
 
 build:
-  number: 0
-  missing_dso_whitelist:  # [linux]
-    - $RPATH/ld64.so.1    # [linux]
-  skip: True  # [py<36 or py>313]
+  number: 1
+  skip: True  # [py<39 or py>314]
 
 requirements:
   build:
@@ -29,14 +27,12 @@ requirements:
   host:
     - pip
     - python
-    - wheel
     - setuptools
-    - cython >=3.0,<4.0
-    - numpy >=1.19.3,<3.0.0
+    - cython >=3.1,<4.0
+    - numpy {{ numpy }}
   run:
     - python
-    - numpy >=1.15.0,<3.0.0  # [py<39]
-    - numpy >=1.19.0,<3.0.0  # [py>=39]
+    - numpy {{ numpy }}
 
 test:
   imports:
@@ -49,7 +45,7 @@ test:
   requires:
     - pip
     - pytest
-    - hypothesis
+    - hypothesis >=4.0.0,<7.0.0
 
 about:
   home: https://github.com/explosion/cython-blis
@@ -57,7 +53,7 @@ about:
   license_family: BSD
   license_file:
     - LICENSE
-  summary: 'Fast matrix-multiplication as a self-contained Python library - no system dependencies!'
+  summary: Fast matrix-multiplication as a self-contained Python library - no system dependencies!
   description: |
     cython-blis provides the Blis linear algebra routines as a self-contained Python C-extension.
   doc_url: https://github.com/explosion/cython-blis/blob/master/README.md


### PR DESCRIPTION
cython-blis 1.3.3 - rebuild for py314

**Destination channel:** defaults

### Links

- [PKG-13387](https://anaconda.atlassian.net/browse/PKG-13387)
- [Upstream repository](https://github.com/explosion/cython-blis/tree/release-v1.3.3)

### Explanation of changes:

- rebuild for py314
- fix python constrains
- remove unused recipe components
- remove local cbc

[PKG-13387]: https://anaconda.atlassian.net/browse/PKG-13387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ